### PR TITLE
feat: add privacy level [SD-781]

### DIFF
--- a/docs/reference/api/synthesizers/base.md
+++ b/docs/reference/api/synthesizers/base.md
@@ -1,1 +1,7 @@
 ::: ydata.sdk.synthesizers.synthesizer.BaseSynthesizer
+
+# PrivacyLevel
+
+::: ydata.sdk.synthesizers.PrivacyLevel
+    options:
+        show_source: false

--- a/docs/reference/api/synthesizers/regular.md
+++ b/docs/reference/api/synthesizers/regular.md
@@ -1,1 +1,7 @@
 ::: ydata.sdk.synthesizers.regular.RegularSynthesizer
+
+# PrivacyLevel
+
+::: ydata.sdk.synthesizers.PrivacyLevel
+    options:
+        show_source: false

--- a/docs/reference/api/synthesizers/timeseries.md
+++ b/docs/reference/api/synthesizers/timeseries.md
@@ -1,1 +1,7 @@
 ::: ydata.sdk.synthesizers.timeseries.TimeSeriesSynthesizer
+
+# PrivacyLevel
+
+::: ydata.sdk.synthesizers.PrivacyLevel
+    options:
+        show_source: false

--- a/examples/synthesizers/privacy_example.py
+++ b/examples/synthesizers/privacy_example.py
@@ -1,0 +1,34 @@
+import os
+
+from ydata.sdk.dataset import get_dataset
+from ydata.sdk.synthesizers import RegularSynthesizer, PrivacyLevel
+
+# Do not forget to add your token as env variables
+os.environ["YDATA_TOKEN"] = '<TOKEN>'  # Remove if already defined
+
+
+def main():
+    """In this example, we demonstrate how to train a synthesizer 
+    with a high-privacy setting from a pandas DataFrame.
+    After training a Regular Synthesizer, we request a sample.
+    """
+    X = get_dataset('titanic')
+
+    # We initialize a regular synthesizer
+    # As long as the synthesizer does not call `fit`, it exists only locally
+    synth = RegularSynthesizer()
+
+    # We train the synthesizer on our dataset setting the privacy level to high
+    synth.fit(
+        X,
+        name="titanic_synthesizer",
+        privacy_level=PrivacyLevel.HIGH_PRIVACY
+    )
+
+    # We request a synthetic dataset with 50 rows
+    sample = synth.sample(n_samples=50)
+    print(sample)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/synthesizers/privacy_example.py
+++ b/examples/synthesizers/privacy_example.py
@@ -1,14 +1,14 @@
 import os
 
 from ydata.sdk.dataset import get_dataset
-from ydata.sdk.synthesizers import RegularSynthesizer, PrivacyLevel
+from ydata.sdk.synthesizers import PrivacyLevel, RegularSynthesizer
 
 # Do not forget to add your token as env variables
 os.environ["YDATA_TOKEN"] = '<TOKEN>'  # Remove if already defined
 
 
 def main():
-    """In this example, we demonstrate how to train a synthesizer 
+    """In this example, we demonstrate how to train a synthesizer
     with a high-privacy setting from a pandas DataFrame.
     After training a Regular Synthesizer, we request a sample.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ dependencies = [
     "pandas>=1.5.0",
     "prettytable==3.6.0",
     "pydantic==1.10.5",
-    "typeguard==2.13.3"
+    "typeguard==2.13.3",
+    "ydata-datascience"
 ]
 
 [project.license]

--- a/src/ydata/sdk/synthesizers/__init__.py
+++ b/src/ydata/sdk/synthesizers/__init__.py
@@ -2,6 +2,7 @@ from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
 from ydata.sdk.synthesizers.regular import RegularSynthesizer
 from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer as Synthesizer
 from ydata.sdk.synthesizers.timeseries import TimeSeriesSynthesizer
+from ydata.core.synthesizers import PrivacyLevel
 
 __all__ = ["RegularSynthesizer", "TimeSeriesSynthesizer",
-           "Synthesizer", "SynthesizersList"]
+           "Synthesizer", "SynthesizersList", "PrivacyLevel"]

--- a/src/ydata/sdk/synthesizers/__init__.py
+++ b/src/ydata/sdk/synthesizers/__init__.py
@@ -1,4 +1,4 @@
-from ydata.core.synthesizers import PrivacyLevel
+from ydata.datascience.common import PrivacyLevel
 from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
 from ydata.sdk.synthesizers.regular import RegularSynthesizer
 from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer as Synthesizer

--- a/src/ydata/sdk/synthesizers/__init__.py
+++ b/src/ydata/sdk/synthesizers/__init__.py
@@ -1,7 +1,8 @@
 from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
+from ydata.sdk.synthesizers._models.privacy import PrivacyLevel
 from ydata.sdk.synthesizers.regular import RegularSynthesizer
 from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer as Synthesizer
 from ydata.sdk.synthesizers.timeseries import TimeSeriesSynthesizer
 
 __all__ = ["RegularSynthesizer", "TimeSeriesSynthesizer",
-           "Synthesizer", "SynthesizersList"]
+           "Synthesizer", "SynthesizersList", "PrivacyLevel"]

--- a/src/ydata/sdk/synthesizers/__init__.py
+++ b/src/ydata/sdk/synthesizers/__init__.py
@@ -1,4 +1,3 @@
-from ydata.sdk.synthesizers._models.privacy import PrivacyLevel
 from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
 from ydata.sdk.synthesizers.regular import RegularSynthesizer
 from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer as Synthesizer

--- a/src/ydata/sdk/synthesizers/__init__.py
+++ b/src/ydata/sdk/synthesizers/__init__.py
@@ -1,5 +1,5 @@
-from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
 from ydata.sdk.synthesizers._models.privacy import PrivacyLevel
+from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
 from ydata.sdk.synthesizers.regular import RegularSynthesizer
 from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer as Synthesizer
 from ydata.sdk.synthesizers.timeseries import TimeSeriesSynthesizer

--- a/src/ydata/sdk/synthesizers/__init__.py
+++ b/src/ydata/sdk/synthesizers/__init__.py
@@ -1,8 +1,8 @@
+from ydata.core.synthesizers import PrivacyLevel
 from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
 from ydata.sdk.synthesizers.regular import RegularSynthesizer
 from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer as Synthesizer
 from ydata.sdk.synthesizers.timeseries import TimeSeriesSynthesizer
-from ydata.core.synthesizers import PrivacyLevel
 
 __all__ = ["RegularSynthesizer", "TimeSeriesSynthesizer",
            "Synthesizer", "SynthesizersList", "PrivacyLevel"]

--- a/src/ydata/sdk/synthesizers/__init__.py
+++ b/src/ydata/sdk/synthesizers/__init__.py
@@ -5,4 +5,4 @@ from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer as Synthesizer
 from ydata.sdk.synthesizers.timeseries import TimeSeriesSynthesizer
 
 __all__ = ["RegularSynthesizer", "TimeSeriesSynthesizer",
-           "Synthesizer", "SynthesizersList", "PrivacyLevel"]
+           "Synthesizer", "SynthesizersList"]

--- a/src/ydata/sdk/synthesizers/_models/privacy.py
+++ b/src/ydata/sdk/synthesizers/_models/privacy.py
@@ -1,8 +1,0 @@
-from enum import Enum, auto
-
-
-class PrivacyLevel(Enum):
-    """Privacy level exposed to the end-user."""
-    HIGH_FIDELITY = auto()
-    HIGH_PRIVACY = auto()
-    BALANCED_PRIVACY_FIDELITY = auto()

--- a/src/ydata/sdk/synthesizers/_models/privacy.py
+++ b/src/ydata/sdk/synthesizers/_models/privacy.py
@@ -1,0 +1,8 @@
+from enum import Enum, auto
+
+
+class PrivacyLevel(Enum):
+    """Privacy level exposed to the end-user."""
+    HIGH_FIDELITY = auto()
+    HIGH_PRIVACY = auto()
+    BALANCED_PRIVACY_FIDELITY = auto()

--- a/src/ydata/sdk/synthesizers/regular.py
+++ b/src/ydata/sdk/synthesizers/regular.py
@@ -6,7 +6,7 @@ from ydata.sdk.common.exceptions import InputError
 from ydata.sdk.datasources import DataSource
 from ydata.sdk.datasources._models.datatype import DataSourceType
 from ydata.sdk.datasources._models.metadata.data_types import DataType
-from ydata.sdk.synthesizers._models.privacy import PrivacyLevel
+from ydata.core.enum import PrivacyLevel
 from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer
 
 

--- a/src/ydata/sdk/synthesizers/regular.py
+++ b/src/ydata/sdk/synthesizers/regular.py
@@ -6,6 +6,7 @@ from ydata.sdk.common.exceptions import InputError
 from ydata.sdk.datasources import DataSource
 from ydata.sdk.datasources._models.datatype import DataSourceType
 from ydata.sdk.datasources._models.metadata.data_types import DataType
+from ydata.sdk.synthesizers._models.privacy import PrivacyLevel
 from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer
 
 
@@ -27,6 +28,7 @@ class RegularSynthesizer(BaseSynthesizer):
         return self._sample(payload={"numberOfRecords": n_samples})
 
     def fit(self, X: Union[DataSource, pdDataFrame],
+            privacy_level: PrivacyLevel = PrivacyLevel.HIGH_FIDELITY,
             entity_id_cols: Optional[Union[str, List[str]]] = None,
             generate_cols: Optional[List[str]] = None,
             exclude_cols: Optional[List[str]] = None,
@@ -40,6 +42,7 @@ class RegularSynthesizer(BaseSynthesizer):
 
         Arguments:
             X (Union[DataSource, pandas.DataFrame]): Training dataset
+            privacy_level (PrivacyLevel): Synthesizer privacy level (defaults to high fidelity)
             entity_id_cols (Union[str, List[str]]): (optional) columns representing entities ID
             generate_cols (List[str]): (optional) columns that should be synthesized
             exclude_cols (List[str]): (optional) columns that should not be synthesized
@@ -50,7 +53,7 @@ class RegularSynthesizer(BaseSynthesizer):
         """
         BaseSynthesizer.fit(self, X=X, datatype=DataSourceType.TABULAR, entity_id_cols=entity_id_cols,
                             generate_cols=generate_cols, exclude_cols=exclude_cols, dtypes=dtypes,
-                            target=target, name=name, anonymize=anonymize)
+                            target=target, name=name, anonymize=anonymize, privacy_level=privacy_level)
 
     def __repr__(self):
         if self._model is not None:

--- a/src/ydata/sdk/synthesizers/regular.py
+++ b/src/ydata/sdk/synthesizers/regular.py
@@ -2,11 +2,11 @@ from typing import Dict, List, Optional, Union
 
 from pandas import DataFrame as pdDataFrame
 
+from ydata.core.enum import PrivacyLevel
 from ydata.sdk.common.exceptions import InputError
 from ydata.sdk.datasources import DataSource
 from ydata.sdk.datasources._models.datatype import DataSourceType
 from ydata.sdk.datasources._models.metadata.data_types import DataType
-from ydata.core.enum import PrivacyLevel
 from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer
 
 

--- a/src/ydata/sdk/synthesizers/regular.py
+++ b/src/ydata/sdk/synthesizers/regular.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional, Union
 
 from pandas import DataFrame as pdDataFrame
 
-from ydata.core.enum import PrivacyLevel
+from ydata.core.synthesizers import PrivacyLevel
 from ydata.sdk.common.exceptions import InputError
 from ydata.sdk.datasources import DataSource
 from ydata.sdk.datasources._models.datatype import DataSourceType

--- a/src/ydata/sdk/synthesizers/regular.py
+++ b/src/ydata/sdk/synthesizers/regular.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional, Union
 
 from pandas import DataFrame as pdDataFrame
 
-from ydata.core.synthesizers import PrivacyLevel
+from ydata.datascience.common import PrivacyLevel
 from ydata.sdk.common.exceptions import InputError
 from ydata.sdk.datasources import DataSource
 from ydata.sdk.datasources._models.datatype import DataSourceType

--- a/src/ydata/sdk/synthesizers/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/synthesizer.py
@@ -9,7 +9,7 @@ from pandas import DataFrame as pdDataFrame
 from pandas import read_csv
 from typeguard import typechecked
 
-from ydata.core.synthesizers import PrivacyLevel
+from ydata.datascience.common import PrivacyLevel
 from ydata.sdk.common.client import Client
 from ydata.sdk.common.client.utils import init_client
 from ydata.sdk.common.config import BACKOFF, LOG_LEVEL

--- a/src/ydata/sdk/synthesizers/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/synthesizer.py
@@ -27,6 +27,7 @@ from ydata.sdk.synthesizers._models.status import PrepareState, Status
 from ydata.sdk.synthesizers._models.synthesizer import Synthesizer as mSynthesizer
 from ydata.sdk.synthesizers._models.synthesizer_type import SynthesizerType
 from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
+from ydata.sdk.synthesizers._models.privacy import PrivacyLevel
 from ydata.sdk.utils.model_mixin import ModelFactoryMixin
 from ydata.sdk.utils.model_utils import filter_dict
 
@@ -60,6 +61,7 @@ class BaseSynthesizer(ABC, ModelFactoryMixin):
         self._logger = create_logger(__name__, level=LOG_LEVEL)
 
     def fit(self, X: Union[DataSource, pdDataFrame],
+            privacy_level: PrivacyLevel = PrivacyLevel.HIGH_FIDELITY,
             datatype: Optional[Union[DataSourceType, str]] = None,
             sortbykey: Optional[Union[str, List[str]]] = None,
             entity_id_cols: Optional[Union[str, List[str]]] = None,
@@ -81,6 +83,7 @@ class BaseSynthesizer(ABC, ModelFactoryMixin):
 
         Arguments:
             X (Union[DataSource, pandas.DataFrame]): Training dataset
+            privacy_level (PrivacyLevel): Synthesizer privacy level (defaults to high fidelity)
             datatype (Optional[Union[DataSourceType, str]]): (optional) Dataset datatype - required if `X` is a [`pandas.DataFrame`][pandas.DataFrame]
             sortbykey (Union[str, List[str]]): (optional) column(s) to use to sort timeseries datasets
             entity_id_cols (Union[str, List[str]]): (optional) columns representing entities ID
@@ -118,7 +121,7 @@ class BaseSynthesizer(ABC, ModelFactoryMixin):
             dataset_attrs = DataSourceAttrs(**dataset_attrs)
 
         self._fit_from_datasource(
-            X=_X, dataset_attrs=dataset_attrs, target=target, name=name, anonymize=anonymize)
+            X=_X, dataset_attrs=dataset_attrs, target=target, name=name, anonymize=anonymize, privacy_level=privacy_level)
 
     @staticmethod
     def _init_datasource_attributes(
@@ -216,6 +219,7 @@ class BaseSynthesizer(ABC, ModelFactoryMixin):
     def _fit_from_datasource(
         self,
         X: DataSource,
+        privacy_level: PrivacyLevel = PrivacyLevel.HIGH_FIDELITY,
         dataset_attrs: Optional[DataSourceAttrs] = None,
         target: Optional[str] = None,
         name: Optional[str] = None,
@@ -231,6 +235,9 @@ class BaseSynthesizer(ABC, ModelFactoryMixin):
                 'dataType': X.datatype,
                 "columns": columns,
             },
+            'extraData': {
+                'privacy_level': privacy_level 
+            }
         }
         if anonymize is not None:
             payload["extraData"] = {"anonymize": anonymize}

--- a/src/ydata/sdk/synthesizers/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/synthesizer.py
@@ -9,7 +9,7 @@ from pandas import DataFrame as pdDataFrame
 from pandas import read_csv
 from typeguard import typechecked
 
-from ydata.core.enum import PrivacyLevel
+from ydata.core.synthesizers import PrivacyLevel
 from ydata.sdk.common.client import Client
 from ydata.sdk.common.client.utils import init_client
 from ydata.sdk.common.config import BACKOFF, LOG_LEVEL

--- a/src/ydata/sdk/synthesizers/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/synthesizer.py
@@ -236,7 +236,7 @@ class BaseSynthesizer(ABC, ModelFactoryMixin):
                 "columns": columns,
             },
             'extraData': {
-                'privacy_level': privacy_level 
+                'privacy_level': privacy_level.value 
             }
         }
         if anonymize is not None:

--- a/src/ydata/sdk/synthesizers/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/synthesizer.py
@@ -28,6 +28,7 @@ from ydata.sdk.synthesizers._models.status import PrepareState, Status
 from ydata.sdk.synthesizers._models.synthesizer import Synthesizer as mSynthesizer
 from ydata.sdk.synthesizers._models.synthesizer_type import SynthesizerType
 from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
+from ydata.core.enum import PrivacyLevel
 from ydata.sdk.utils.model_mixin import ModelFactoryMixin
 from ydata.sdk.utils.model_utils import filter_dict
 

--- a/src/ydata/sdk/synthesizers/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/synthesizer.py
@@ -240,7 +240,7 @@ class BaseSynthesizer(ABC, ModelFactoryMixin):
             }
         }
         if anonymize is not None:
-            payload["extraData"] = {"anonymize": anonymize}
+            payload["extraData"]["anonymize"] = anonymize
         if target is not None:
             payload['metadata']['target'] = target
 

--- a/src/ydata/sdk/synthesizers/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/synthesizer.py
@@ -23,7 +23,6 @@ from ydata.sdk.datasources._models.datatype import DataSourceType
 from ydata.sdk.datasources._models.metadata.data_types import DataType
 from ydata.sdk.datasources._models.metadata.metadata import Metadata
 from ydata.sdk.datasources._models.status import Status as dsStatus
-from ydata.sdk.synthesizers._models.privacy import PrivacyLevel
 from ydata.sdk.synthesizers._models.status import PrepareState, Status
 from ydata.sdk.synthesizers._models.synthesizer import Synthesizer as mSynthesizer
 from ydata.sdk.synthesizers._models.synthesizer_type import SynthesizerType

--- a/src/ydata/sdk/synthesizers/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/synthesizer.py
@@ -23,11 +23,11 @@ from ydata.sdk.datasources._models.datatype import DataSourceType
 from ydata.sdk.datasources._models.metadata.data_types import DataType
 from ydata.sdk.datasources._models.metadata.metadata import Metadata
 from ydata.sdk.datasources._models.status import Status as dsStatus
+from ydata.sdk.synthesizers._models.privacy import PrivacyLevel
 from ydata.sdk.synthesizers._models.status import PrepareState, Status
 from ydata.sdk.synthesizers._models.synthesizer import Synthesizer as mSynthesizer
 from ydata.sdk.synthesizers._models.synthesizer_type import SynthesizerType
 from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
-from ydata.sdk.synthesizers._models.privacy import PrivacyLevel
 from ydata.sdk.utils.model_mixin import ModelFactoryMixin
 from ydata.sdk.utils.model_utils import filter_dict
 
@@ -236,7 +236,7 @@ class BaseSynthesizer(ABC, ModelFactoryMixin):
                 "columns": columns,
             },
             'extraData': {
-                'privacy_level': privacy_level.value 
+                'privacy_level': privacy_level.value
             }
         }
         if anonymize is not None:

--- a/src/ydata/sdk/synthesizers/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/synthesizer.py
@@ -9,6 +9,7 @@ from pandas import DataFrame as pdDataFrame
 from pandas import read_csv
 from typeguard import typechecked
 
+from ydata.core.enum import PrivacyLevel
 from ydata.sdk.common.client import Client
 from ydata.sdk.common.client.utils import init_client
 from ydata.sdk.common.config import BACKOFF, LOG_LEVEL
@@ -27,7 +28,6 @@ from ydata.sdk.synthesizers._models.status import PrepareState, Status
 from ydata.sdk.synthesizers._models.synthesizer import Synthesizer as mSynthesizer
 from ydata.sdk.synthesizers._models.synthesizer_type import SynthesizerType
 from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
-from ydata.core.enum import PrivacyLevel
 from ydata.sdk.utils.model_mixin import ModelFactoryMixin
 from ydata.sdk.utils.model_utils import filter_dict
 

--- a/src/ydata/sdk/synthesizers/timeseries.py
+++ b/src/ydata/sdk/synthesizers/timeseries.py
@@ -6,7 +6,7 @@ from ydata.sdk.common.exceptions import InputError
 from ydata.sdk.datasources import DataSource
 from ydata.sdk.datasources._models.datatype import DataSourceType
 from ydata.sdk.datasources._models.metadata.data_types import DataType
-from ydata.sdk.synthesizers._models.privacy import PrivacyLevel
+from ydata.core.enum import PrivacyLevel
 from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer
 
 

--- a/src/ydata/sdk/synthesizers/timeseries.py
+++ b/src/ydata/sdk/synthesizers/timeseries.py
@@ -2,11 +2,11 @@ from typing import Dict, List, Optional, Union
 
 from pandas import DataFrame as pdDataFrame
 
+from ydata.core.enum import PrivacyLevel
 from ydata.sdk.common.exceptions import InputError
 from ydata.sdk.datasources import DataSource
 from ydata.sdk.datasources._models.datatype import DataSourceType
 from ydata.sdk.datasources._models.metadata.data_types import DataType
-from ydata.core.enum import PrivacyLevel
 from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer
 
 

--- a/src/ydata/sdk/synthesizers/timeseries.py
+++ b/src/ydata/sdk/synthesizers/timeseries.py
@@ -6,6 +6,7 @@ from ydata.sdk.common.exceptions import InputError
 from ydata.sdk.datasources import DataSource
 from ydata.sdk.datasources._models.datatype import DataSourceType
 from ydata.sdk.datasources._models.metadata.data_types import DataType
+from ydata.sdk.synthesizers._models.privacy import PrivacyLevel
 from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer
 
 
@@ -31,6 +32,7 @@ class TimeSeriesSynthesizer(BaseSynthesizer):
 
     def fit(self, X: Union[DataSource, pdDataFrame],
             sortbykey: Optional[Union[str, List[str]]],
+            privacy_level: PrivacyLevel = PrivacyLevel.HIGH_FIDELITY,
             entity_id_cols: Optional[Union[str, List[str]]] = None,
             generate_cols: Optional[List[str]] = None,
             exclude_cols: Optional[List[str]] = None,
@@ -45,6 +47,7 @@ class TimeSeriesSynthesizer(BaseSynthesizer):
         Arguments:
             X (Union[DataSource, pandas.DataFrame]): Training dataset
             sortbykey (Union[str, List[str]]): column(s) to use to sort timeseries datasets
+            privacy_level (PrivacyLevel): Synthesizer privacy level (defaults to high fidelity)
             entity_id_cols (Union[str, List[str]]): (optional) columns representing entities ID
             generate_cols (List[str]): (optional) columns that should be synthesized
             exclude_cols (List[str]): (optional) columns that should not be synthesized
@@ -53,9 +56,9 @@ class TimeSeriesSynthesizer(BaseSynthesizer):
             name (Optional[str]): (optional) Synthesizer instance name
             anonymize (Optional[str]): (optional) fields to anonymize and the anonymization strategy
         """
-        BaseSynthesizer.fit(self, X=X, datatype=DataSourceType.TIMESERIES, sortbykey=sortbykey, entity_id_cols=entity_id_cols,
-                            generate_cols=generate_cols, exclude_cols=exclude_cols, dtypes=dtypes,  target=target,
-                            name=name, anonymize=anonymize)
+        BaseSynthesizer.fit(self, X=X, datatype=DataSourceType.TIMESERIES, sortbykey=sortbykey, 
+                            entity_id_cols=entity_id_cols, generate_cols=generate_cols, exclude_cols=exclude_cols, 
+                            dtypes=dtypes, target=target, name=name, anonymize=anonymize, privacy_level=privacy_level)
 
     def __repr__(self):
         if self._model is not None:

--- a/src/ydata/sdk/synthesizers/timeseries.py
+++ b/src/ydata/sdk/synthesizers/timeseries.py
@@ -56,8 +56,8 @@ class TimeSeriesSynthesizer(BaseSynthesizer):
             name (Optional[str]): (optional) Synthesizer instance name
             anonymize (Optional[str]): (optional) fields to anonymize and the anonymization strategy
         """
-        BaseSynthesizer.fit(self, X=X, datatype=DataSourceType.TIMESERIES, sortbykey=sortbykey, 
-                            entity_id_cols=entity_id_cols, generate_cols=generate_cols, exclude_cols=exclude_cols, 
+        BaseSynthesizer.fit(self, X=X, datatype=DataSourceType.TIMESERIES, sortbykey=sortbykey,
+                            entity_id_cols=entity_id_cols, generate_cols=generate_cols, exclude_cols=exclude_cols,
                             dtypes=dtypes, target=target, name=name, anonymize=anonymize, privacy_level=privacy_level)
 
     def __repr__(self):

--- a/src/ydata/sdk/synthesizers/timeseries.py
+++ b/src/ydata/sdk/synthesizers/timeseries.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional, Union
 
 from pandas import DataFrame as pdDataFrame
 
-from ydata.core.synthesizers import PrivacyLevel
+from ydata.datascience.common import PrivacyLevel
 from ydata.sdk.common.exceptions import InputError
 from ydata.sdk.datasources import DataSource
 from ydata.sdk.datasources._models.datatype import DataSourceType

--- a/src/ydata/sdk/synthesizers/timeseries.py
+++ b/src/ydata/sdk/synthesizers/timeseries.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional, Union
 
 from pandas import DataFrame as pdDataFrame
 
-from ydata.core.enum import PrivacyLevel
+from ydata.core.synthesizers import PrivacyLevel
 from ydata.sdk.common.exceptions import InputError
 from ydata.sdk.datasources import DataSource
 from ydata.sdk.datasources._models.datatype import DataSourceType
@@ -13,8 +13,7 @@ from ydata.sdk.synthesizers.synthesizer import BaseSynthesizer
 class TimeSeriesSynthesizer(BaseSynthesizer):
 
     def sample(self, n_entities: Optional[int] = None) -> pdDataFrame:
-        """Sample from a [`TimeSeriesSynthesizer`][ydata.sdk.synthesizers.TimeS
-        eriesSynthesizer] instance.
+        """Sample from a [`TimeSeriesSynthesizer`][ydata.sdk.synthesizers.TimeSeriesSynthesizer] instance.
 
         If a training dataset was not using any `entity` column, the Synthesizer assumes a single entity.
         A [`TimeSeriesSynthesizer`][ydata.sdk.synthesizers.TimeSeriesSynthesizer] always sample the full trajectory of its entities.


### PR DESCRIPTION
This PR adds the privacy level parameter to the public SDK.
I was only able to test the creation of the Synthesizer. The training fails because the DS lib version with the privacy layer is not yet deployed in the dev environment.

![Screenshot from 2023-03-22 17-24-55](https://user-images.githubusercontent.com/21283729/226988634-d8ba3e91-adfa-4373-8e6b-c3f776ae0b91.png)

Here is a usage example:

```python
from ydata.sdk.synthesizers import RegularSynthesizer, PrivacyLevel
from ydata.sdk.datasources import DataSource

X = DataSource.get('{ds-uid}')
synth = RegularSynthesizer()
synth.fit(X, privacy_level=PrivacyLevel.HIGH_PRIVACY)
sample = synth.sample(n_samples=50)
```