### PR TITLE
fix: no update when the synthesizer fails [SD-797]

### DIFF
--- a/src/ydata/sdk/synthesizers/_models/status.py
+++ b/src/ydata/sdk/synthesizers/_models/status.py
@@ -24,6 +24,7 @@ class TrainingState(StringEnum):
     RUNNING = 'running'
     FINISHED = 'finished'
     FAILED = 'failed'
+    UNKNOWN = 'unknown'
 
 
 class ReportState(StringEnum):

--- a/src/ydata/sdk/synthesizers/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/synthesizer.py
@@ -24,7 +24,7 @@ from ydata.sdk.datasources._models.datatype import DataSourceType
 from ydata.sdk.datasources._models.metadata.data_types import DataType
 from ydata.sdk.datasources._models.metadata.metadata import Metadata
 from ydata.sdk.datasources._models.status import Status as dsStatus
-from ydata.sdk.synthesizers._models.status import PrepareState, TrainingState, ReportState, Status
+from ydata.sdk.synthesizers._models.status import PrepareState, ReportState, Status, TrainingState
 from ydata.sdk.synthesizers._models.synthesizer import Synthesizer as mSynthesizer
 from ydata.sdk.synthesizers._models.synthesizer_type import SynthesizerType
 from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
@@ -388,14 +388,14 @@ class BaseSynthesizer(ABC, ModelFactoryMixin):
         status = Status(api_status.get('state', Status.UNKNOWN.name))
         if status == Status.PREPARE:
             if PrepareState(api_status.get('prepare', {}).get(
-                'state', PrepareState.UNKNOWN.name)) == PrepareState.FAILED:
+                    'state', PrepareState.UNKNOWN.name)) == PrepareState.FAILED:
                 return Status.FAILED
         elif status == Status.TRAIN:
             if TrainingState(api_status.get('training', {}).get(
-                'state', TrainingState.UNKNOWN.name)) == TrainingState.FAILED:
+                    'state', TrainingState.UNKNOWN.name)) == TrainingState.FAILED:
                 return Status.FAILED
         elif status == Status.REPORT:
             if ReportState(api_status.get('report', {}).get(
-                'state', ReportState.UNKNOWN.name)) == ReportState.FAILED:
+                    'state', ReportState.UNKNOWN.name)) == ReportState.FAILED:
                 return Status.FAILED
         return status

--- a/src/ydata/sdk/synthesizers/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/synthesizer.py
@@ -24,7 +24,7 @@ from ydata.sdk.datasources._models.datatype import DataSourceType
 from ydata.sdk.datasources._models.metadata.data_types import DataType
 from ydata.sdk.datasources._models.metadata.metadata import Metadata
 from ydata.sdk.datasources._models.status import Status as dsStatus
-from ydata.sdk.synthesizers._models.status import PrepareState, Status
+from ydata.sdk.synthesizers._models.status import PrepareState, TrainingState, ReportState, Status
 from ydata.sdk.synthesizers._models.synthesizer import Synthesizer as mSynthesizer
 from ydata.sdk.synthesizers._models.synthesizer_type import SynthesizerType
 from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
@@ -386,8 +386,16 @@ class BaseSynthesizer(ABC, ModelFactoryMixin):
             Synthesizer Status
         """
         status = Status(api_status.get('state', Status.UNKNOWN.name))
-        prepare = PrepareState(api_status.get('prepare', {}).get(
-            'state', PrepareState.UNKNOWN.name))
-        if prepare == PrepareState.FAILED:
-            status = Status.FAILED
+        if status == Status.PREPARE:
+            if PrepareState(api_status.get('prepare', {}).get(
+                'state', PrepareState.UNKNOWN.name)) == PrepareState.FAILED:
+                return Status.FAILED
+        elif status == Status.TRAIN:
+            if TrainingState(api_status.get('training', {}).get(
+                'state', TrainingState.UNKNOWN.name)) == TrainingState.FAILED:
+                return Status.FAILED
+        elif status == Status.REPORT:
+            if ReportState(api_status.get('report', {}).get(
+                'state', ReportState.UNKNOWN.name)) == ReportState.FAILED:
+                return Status.FAILED
         return status


### PR DESCRIPTION
When the synthesizer training fails, the SDK was not getting updated. As a consequence, it stayed stuck indefinitely waiting for a response. The issue is now fixed. The attached image shows the error presented to the end user.

![error-sdk](https://user-images.githubusercontent.com/21283729/230240616-6cc23c7e-494c-43e6-9f0d-9bf9c1d566c6.png)