### PR TITLE
fix: synthesizer status depending on report status

### DIFF
--- a/src/ydata/sdk/synthesizers/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/synthesizer.py
@@ -24,7 +24,7 @@ from ydata.sdk.datasources._models.datatype import DataSourceType
 from ydata.sdk.datasources._models.metadata.data_types import DataType
 from ydata.sdk.datasources._models.metadata.metadata import Metadata
 from ydata.sdk.datasources._models.status import Status as dsStatus
-from ydata.sdk.synthesizers._models.status import PrepareState, ReportState, Status, TrainingState
+from ydata.sdk.synthesizers._models.status import PrepareState, Status, TrainingState
 from ydata.sdk.synthesizers._models.synthesizer import Synthesizer as mSynthesizer
 from ydata.sdk.synthesizers._models.synthesizer_type import SynthesizerType
 from ydata.sdk.synthesizers._models.synthesizers_list import SynthesizersList
@@ -403,7 +403,5 @@ class BaseSynthesizer(ABC, ModelFactoryMixin):
                     'state', TrainingState.UNKNOWN.name)) == TrainingState.FAILED:
                 return Status.FAILED
         elif status == Status.REPORT:
-            if ReportState(api_status.get('report', {}).get(
-                    'state', ReportState.UNKNOWN.name)) == ReportState.FAILED:
-                return Status.FAILED
+            return Status.READY
         return status


### PR DESCRIPTION
by construction, if it passes the training phase check it should be good to go
I tested on dev and it was enough to start the sample without waiting for the report to complete, but I was not able to test an example where the report fails