### PR TITLE
feat: introduce 2 new ways to define the DEFAULT_PROJECT

### DIFF
--- a/src/ydata/sdk/common/client/client.py
+++ b/src/ydata/sdk/common/client/client.py
@@ -47,6 +47,8 @@ class Client(metaclass=SingletonClient):
 
     codes = codes
 
+    DEFAULT_PROJECT: Optional[Project] = environ.get("DEFAULT_PROJECT", None)
+
     def __init__(self, credentials: Optional[Union[str, Dict]] = None, project: Optional[Project] = None, set_as_global: bool = False):
         self._base_url = environ.get("YDATA_BASE_URL", DEFAULT_URL)
         self._scheme = 'https'
@@ -56,9 +58,17 @@ class Client(metaclass=SingletonClient):
 
         self._handshake()
 
-        self._default_project = project or self._get_default_project(credentials)
+        self._default_project = project or Client.DEFAULT_PROJECT or self._get_default_project(credentials)
         if set_as_global:
             self.__set_global()
+
+    @property
+    def project(self) -> Project:
+        return Client.DEFAULT_PROJECT or self._default_project
+
+    @project.setter
+    def project(self, value: Project):
+        self._default_project = value
 
     def post(
         self, endpoint: str, data: Optional[Dict] = None, json: Optional[Dict] = None,

--- a/src/ydata/sdk/common/client/client.py
+++ b/src/ydata/sdk/common/client/client.py
@@ -58,7 +58,8 @@ class Client(metaclass=SingletonClient):
 
         self._handshake()
 
-        self._default_project = project or Client.DEFAULT_PROJECT or self._get_default_project(credentials)
+        self._default_project = project or Client.DEFAULT_PROJECT or self._get_default_project(
+            credentials)
         if set_as_global:
             self.__set_global()
 

--- a/src/ydata/sdk/connectors/connector.py
+++ b/src/ydata/sdk/connectors/connector.py
@@ -55,6 +55,10 @@ class Connector(ModelFactoryMixin):
     def type(self) -> ConnectorType:
         return self._model.type
 
+    @property
+    def project(self) -> Project:
+        return self._project or self._client.project
+
     @staticmethod
     @init_client
     def get(uid: UID, project: Optional[Project] = None, client: Optional[Client] = None) -> "Connector":

--- a/src/ydata/sdk/datasources/datasource.py
+++ b/src/ydata/sdk/datasources/datasource.py
@@ -68,6 +68,10 @@ class DataSource(ModelFactoryMixin):
         return self._model.datatype
 
     @property
+    def project(self) -> Project:
+        return self._project or self._client.project
+
+    @property
     def status(self) -> Status:
         try:
             self._model = self.get(self._model.uid, self._client)._model

--- a/src/ydata/sdk/synthesizers/multitable.py
+++ b/src/ydata/sdk/synthesizers/multitable.py
@@ -28,7 +28,8 @@ class MultiTableSynthesizer(BaseSynthesizer):
             The synthesizer instance is created in the backend only when the `fit` method is called.
 
     Arguments:
-        write_connector (UID): Connector of type RDBMS to be used to write the samples
+        write_connector (UID | Connector): Connector of type RDBMS to be used to write the samples
+        uid (UID): (optional) UID to identify this synthesizer
         name (str): (optional) Name to be used when creating the synthesizer. Calculated internally if not provided
         client (Client): (optional) Client to connect to the backend
     """
@@ -126,3 +127,4 @@ class MultiTableSynthesizer(BaseSynthesizer):
                 f"Invalid type `{write_connector.type}` for the provided connector")
 
         return write_connector
+

--- a/src/ydata/sdk/synthesizers/multitable.py
+++ b/src/ydata/sdk/synthesizers/multitable.py
@@ -127,4 +127,3 @@ class MultiTableSynthesizer(BaseSynthesizer):
                 f"Invalid type `{write_connector.type}` for the provided connector")
 
         return write_connector
-

--- a/src/ydata/sdk/synthesizers/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/synthesizer.py
@@ -61,6 +61,10 @@ class BaseSynthesizer(ABC, ModelFactoryMixin):
         self._client = client
         self._logger = create_logger(__name__, level=LOG_LEVEL)
 
+    @property
+    def project(self) -> Project:
+        return self._project or self._client.project
+
     def fit(self, X: Union[DataSource, pdDataFrame],
             privacy_level: PrivacyLevel = PrivacyLevel.HIGH_FIDELITY,
             datatype: Optional[Union[DataSourceType, str]] = None,


### PR DESCRIPTION
Two ways of setting default project globally:

Through environment variable called `DEFAULT_PROJECT`, if defined outside the code scope, otherwise example on how to define it

```python
from os import environ

environ['DEFAULT_PROJECT'] = '<uid>'
```

Using the Client that is used by the SDK

```python
from ydata.sdk import Client

Client.DEFAULT_PROJECT = '<uid>'
```

`Client.DEFAULT_PROJECT` has priority if defined and it sets ifself with the value that comes from the environment, if any.
If neither `Client.DEFAULT_PROJECT` or the environment are set, it reverts to the default behaviour, which basically get the project from the API which should be your "My First Project"