### PR TITLE
feat: Support for schema in connectors and datasources

### DIFF
--- a/src/ydata/sdk/common/model.py
+++ b/src/ydata/sdk/common/model.py
@@ -8,5 +8,6 @@ class BaseModel(PydanticBaseModel):
     All datamodel from YData SDK inherits from this class.
     """
     class Config:
-        extra = Extra.ignore
         allow_population_by_field_name = True
+        extra = Extra.ignore
+        use_enum_values = True

--- a/src/ydata/sdk/common/pydantic_utils.py
+++ b/src/ydata/sdk/common/pydantic_utils.py
@@ -1,0 +1,30 @@
+"""Alias generators for converting between different capitalization conventions."""
+import re
+
+__all__ = ('to_pascal', 'to_camel', 'to_snake')
+
+
+def to_pascal(snake: str) -> str:
+    """Convert a snake_case string to PascalCase.
+
+    Args:
+        snake: The string to convert.
+
+    Returns:
+        The PascalCase string.
+    """
+    camel = snake.title()
+    return re.sub('([0-9A-Za-z])_(?=[0-9A-Z])', lambda m: m.group(1), camel)
+
+
+def to_camel(snake: str) -> str:
+    """Convert a snake_case string to camelCase.
+
+    Args:
+        snake: The string to convert.
+
+    Returns:
+        The converted camelCase string.
+    """
+    camel = to_pascal(snake)
+    return re.sub('(^_*[A-Z])', lambda m: m.group(1).lower(), camel)

--- a/src/ydata/sdk/common/pydantic_utils.py
+++ b/src/ydata/sdk/common/pydantic_utils.py
@@ -1,7 +1,7 @@
 """Alias generators for converting between different capitalization conventions."""
 import re
 
-__all__ = ('to_pascal', 'to_camel', 'to_snake')
+__all__ = ('to_pascal', 'to_camel')
 
 
 def to_pascal(snake: str) -> str:

--- a/src/ydata/sdk/connectors/_models/connector_type.py
+++ b/src/ydata/sdk/connectors/_models/connector_type.py
@@ -1,5 +1,8 @@
 
 from enum import Enum
+from typing import Union
+
+from ydata.sdk.common.exceptions import InvalidConnectorError
 
 
 class ConnectorType(Enum):
@@ -19,3 +22,18 @@ class ConnectorType(Enum):
     """BigQuery connector"""
     SNOWFLAKE = "snowflake"
     """Snowflake connector"""
+
+    @property
+    def is_rdbms(self) -> bool:
+        return self in [ConnectorType.AZURE_SQL, ConnectorType.MYSQL, ConnectorType.BIGQUERY, ConnectorType.SNOWFLAKE]
+
+    @staticmethod
+    def _init_connector_type(connector_type: Union["ConnectorType", str]) -> "ConnectorType":
+        if isinstance(connector_type, str):
+            try:
+                connector_type = ConnectorType(connector_type)
+            except Exception:
+                c_list = ", ".join([c.value for c in ConnectorType])
+                raise InvalidConnectorError(
+                    f"ConnectorType '{connector_type}' does not exist.\nValid connector types are: {c_list}.")
+        return connector_type

--- a/src/ydata/sdk/connectors/_models/rdbms_connector.py
+++ b/src/ydata/sdk/connectors/_models/rdbms_connector.py
@@ -1,0 +1,10 @@
+from typing import Optional
+
+from pydantic import Field
+from ydata.sdk.connectors._models.schema import Schema
+
+from .connector import Connector
+
+
+class RDBMSConnector(Connector):
+    db_schema: Optional[Schema] = Field(None, alias="schema")

--- a/src/ydata/sdk/connectors/_models/rdbms_connector.py
+++ b/src/ydata/sdk/connectors/_models/rdbms_connector.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from pydantic import Field
+
 from ydata.sdk.connectors._models.schema import Schema
 
 from .connector import Connector

--- a/src/ydata/sdk/connectors/_models/schema.py
+++ b/src/ydata/sdk/connectors/_models/schema.py
@@ -1,10 +1,9 @@
 from typing import List, Optional
 
 from pydantic import Field
-from pydantic.dataclasses import dataclass
 
-from ydata.sdk.common.pydantic_utils import to_camel
 from ydata.sdk.common.model import BaseModel
+from ydata.sdk.common.pydantic_utils import to_camel
 
 
 class BaseConfig(BaseModel.Config):

--- a/src/ydata/sdk/connectors/_models/schema.py
+++ b/src/ydata/sdk/connectors/_models/schema.py
@@ -1,0 +1,44 @@
+from typing import List, Optional
+
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+
+from ydata.sdk.common.pydantic_utils import to_camel
+from ydata.sdk.common.model import BaseModel
+
+
+class BaseConfig(BaseModel.Config):
+    alias_generator = to_camel
+
+
+class TableColumn(BaseModel):
+    """Class to store the information of a Column table."""
+
+    name: str
+    variable_type: str  # change this to the datatypes
+    primary_key: Optional[bool]
+    is_foreign_key: Optional[bool]
+    foreign_keys: list
+    nullable: bool
+
+    Config = BaseConfig
+
+
+class Table(BaseModel):
+    """Class to store the table columns information."""
+
+    name: str
+    columns: List[TableColumn]
+    primary_keys: List[TableColumn]
+    foreign_keys: List[TableColumn]
+
+    Config = BaseConfig
+
+
+class Schema(BaseModel):
+    """Class to store the database schema information."""
+
+    name: str
+    tables: Optional[List[Table]] = Field(None)
+
+    Config = BaseConfig

--- a/src/ydata/sdk/connectors/connector.py
+++ b/src/ydata/sdk/connectors/connector.py
@@ -10,10 +10,10 @@ from ydata.sdk.common.exceptions import CredentialTypeError
 from ydata.sdk.common.logger import create_logger
 from ydata.sdk.common.types import UID, Project
 from ydata.sdk.connectors._models.connector import Connector as mConnector
-from ydata.sdk.connectors._models.rdbms_connector import RDBMSConnector as mRDBMSConnector
 from ydata.sdk.connectors._models.connector_list import ConnectorsList
 from ydata.sdk.connectors._models.connector_type import ConnectorType
 from ydata.sdk.connectors._models.credentials.credentials import Credentials
+from ydata.sdk.connectors._models.rdbms_connector import RDBMSConnector as mRDBMSConnector
 from ydata.sdk.connectors._models.schema import Schema
 from ydata.sdk.utils.model_mixin import ModelFactoryMixin
 
@@ -83,8 +83,10 @@ class Connector(ModelFactoryMixin):
         response = client.get(f'/connector/{uid}', project=project)
         data = response.json()
         data_type = data["type"]
-        connector_class = _connector_type_to_model(ConnectorType._init_connector_type(data_type))
-        connector = connector_class._init_from_model_data(connector_class._MODEL_CLASS(**data))
+        connector_class = _connector_type_to_model(
+            ConnectorType._init_connector_type(data_type))
+        connector = connector_class._init_from_model_data(
+            connector_class._MODEL_CLASS(**data))
         connector._project = project
 
         return connector

--- a/src/ydata/sdk/connectors/connector.py
+++ b/src/ydata/sdk/connectors/connector.py
@@ -191,5 +191,5 @@ class RDBMSConnector(Connector):
         return self._model.db_schema
 
 
-def _connector_type_to_model(type: ConnectorType) -> Union[Connector, RDBMSConnector]:
-    return RDBMSConnector if type.is_rdbms else Connector
+def _connector_type_to_model(connector_type: ConnectorType) -> Union[Connector, RDBMSConnector]:
+    return RDBMSConnector if connector_type.is_rdbms else Connector

--- a/src/ydata/sdk/datasources/_models/metadata/metadata.py
+++ b/src/ydata/sdk/datasources/_models/metadata/metadata.py
@@ -1,7 +1,8 @@
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
+from ydata.sdk.common.model import BaseModel
 from ydata.sdk.datasources._models.metadata.column import Column
 from ydata.sdk.datasources._models.metadata.warnings import MetadataWarning
 

--- a/src/ydata/sdk/datasources/_models/metadata/warnings.py
+++ b/src/ydata/sdk/datasources/_models/metadata/warnings.py
@@ -1,5 +1,4 @@
-from pydantic import BaseModel
-
+from ydata.sdk.common.model import BaseModel
 from ydata.sdk.datasources._models.metadata.warning_types import Level, WarningType
 
 
@@ -7,14 +6,8 @@ class Details(BaseModel):
     level: Level
     value: str
 
-    class Config:
-        use_enum_values = True
-
 
 class MetadataWarning(BaseModel):
     column: str
     details: Details
     type: WarningType
-
-    class Config:
-        use_enum_values = True

--- a/src/ydata/sdk/datasources/_models/status.py
+++ b/src/ydata/sdk/datasources/_models/status.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from ydata.sdk.common.model import BaseModel
 
 from ydata.core.enum import StringEnum
 

--- a/src/ydata/sdk/datasources/_models/status.py
+++ b/src/ydata/sdk/datasources/_models/status.py
@@ -1,6 +1,5 @@
-from ydata.sdk.common.model import BaseModel
-
 from ydata.core.enum import StringEnum
+from ydata.sdk.common.model import BaseModel
 
 
 class ValidationState(StringEnum):

--- a/src/ydata/sdk/datasources/datasource.py
+++ b/src/ydata/sdk/datasources/datasource.py
@@ -80,7 +80,7 @@ class DataSource(ModelFactoryMixin):
             return Status.UNKNOWN
 
     @property
-    def metadata(self) -> Metadata:
+    def metadata(self) -> Optional[Metadata]:
         return self._model.metadata
 
     @staticmethod
@@ -127,7 +127,7 @@ class DataSource(ModelFactoryMixin):
         datasource_type = CONNECTOR_TO_DATASOURCE.get(
             ConnectorType(data['connector']['type']))
         model = DataSource._model_from_api(data, datasource_type)
-        datasource = ModelFactoryMixin._init_from_model_data(DataSource, model)
+        datasource = DataSource._init_from_model_data(model)
         datasource._project = project
         return datasource
 

--- a/src/ydata/sdk/datasources/datasource.py
+++ b/src/ydata/sdk/datasources/datasource.py
@@ -165,7 +165,7 @@ class DataSource(ModelFactoryMixin):
     ) -> "DataSource":
         model = DataSource._create_model(
             connector, datasource_type, datatype, config, name, project, client)
-        datasource = ModelFactoryMixin._init_from_model_data(DataSource, model)
+        datasource = DataSource._init_from_model_data(model)
 
         if wait_for_metadata:
             datasource._model = DataSource._wait_for_metadata(datasource)._model

--- a/src/ydata/sdk/synthesizers/_models/status.py
+++ b/src/ydata/sdk/synthesizers/_models/status.py
@@ -1,8 +1,9 @@
 from typing import Generic, Optional, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ydata.core.enum import StringEnum
+from ydata.sdk.common.model import BaseModel
 
 T = TypeVar("T")
 

--- a/src/ydata/sdk/synthesizers/_models/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/_models/synthesizer.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+from ydata.sdk.common.model import BaseModel
 
 from .status import Status
 

--- a/src/ydata/sdk/synthesizers/_models/synthesizer.py
+++ b/src/ydata/sdk/synthesizers/_models/synthesizer.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from pydantic import Field
+
 from ydata.sdk.common.model import BaseModel
 
 from .status import Status

--- a/src/ydata/sdk/utils/model_mixin.py
+++ b/src/ydata/sdk/utils/model_mixin.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Type
+from typing import Any, Optional
 
 from ydata.sdk.common.client.client import Client
 from ydata.sdk.common.model import BaseModel
@@ -8,8 +8,8 @@ class ModelFactoryMixin:
     """Mixin for class that implements an interface for an internal model.
     """
 
-    @staticmethod
-    def _init_from_model_data(cls: Type, model: BaseModel, client: Optional[Client] = None) -> Any:
+    @classmethod
+    def _init_from_model_data(cls, model: BaseModel, client: Optional[Client] = None) -> Any:
         o = cls.__new__(cls)
         o._model = model
         o._init_common(client=client)


### PR DESCRIPTION
```python
import os

os.environ['LOG_LEVEL'] = 'DEBUG'

os.environ['YDATA_BASE_URL'] = "fabric.dev.gcp.ydata.ai"
os.environ["YDATA_TOKEN"] = "<TOKEN>"

from ydata.sdk.connectors import Connector

print(Connector.list())

connector = Connector.get('<uid>')
print(f'schema \n{connector.schema}')
```

there is a version available in the pypi with these developments: `ydata-sdk==0.11.0.dev8`