### PR TITLE
fix: remove whitespace from dataset

### DIFF
--- a/src/ydata/sdk/dataset/dataset.py
+++ b/src/ydata/sdk/dataset/dataset.py
@@ -31,6 +31,7 @@ def get_census() -> pdDataFrame:
             "hours-per-week",
             "native-country",
         ],
+        skipinitialspace=True
     )
 
     # Prepare missing values


### PR DESCRIPTION
The original dataset includes whitespaces that need to be trimmed for the example.